### PR TITLE
Updating versions.tf with newrelic provider source as 'newrelic/newrelic'

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    newrelic = ">= 2.2.1"
+    newrelic = {
+      source  = "newrelic/newrelic"
+      version = "~> 2.21"
+    }
   }
 }


### PR DESCRIPTION
With the existing versions.tf , we are facing following error, while trying to execute 'terraform init'

Could not retrieve the list of available versions for provider hashicorp/newrelic: provider registry registry.terraform.io does not have a provider named
│ registry.terraform.io/hashicorp/newrelic
│
│ Did you intend to use newrelic/newrelic? If so, you must specify that source address in each module which requires that provider.

Hence updating the newrelic provider source to 'newrelic/newrelic' in versions.tf